### PR TITLE
ci: publish docker image on release job completion

### DIFF
--- a/.github/workflows/publish-docker-image.yml
+++ b/.github/workflows/publish-docker-image.yml
@@ -3,29 +3,31 @@
 name: Publish Docker image
 
 on:
-  release:
-    types: [published]
+  workflow_run:
+    workflows: ["Conventional Tools Release"]
+    types: ["completed"]
 
 jobs:
   push_to_registry:
     name: Push Docker image to Docker Hub
+    if: ${{ github.event.workflow_run.conclusion == 'success' }}
     runs-on: ubuntu-latest
     steps:
       - name: Check out the repo
         uses: actions/checkout@v3
-      
+
       - name: Log in to Docker Hub
         uses: docker/login-action@v2
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
-      
+
       - name: Extract metadata (tags, labels) for Docker
         id: meta
         uses: docker/metadata-action@v4
         with:
           images: my-docker-hub-namespace/my-docker-hub-repository
-      
+
       - name: Build and push Docker image
         uses: docker/build-push-action@v4
         with:
@@ -33,3 +35,10 @@ jobs:
           push: true
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
+
+  fail:
+    runs-on: ubuntu-latest
+    if: ${{ github.event.workflow_run.conclusion == 'failure' }}
+    steps:
+      - name: Fail
+        run: echo "The release must pass for this to run" && exit 1


### PR DESCRIPTION
## Summary

So it turns out that the `release` event will not get triggered from another CI
job. This is probably why I did not use it for the publish job.

This uses the completion of the conventional tools release job to trigger the
docker image the same way we are doing the npm publish. There is the extract
metadata step, I don't really know how this will work so I think we will just
need to run it and see what gets pushed to the docker hub.

## Type of change

- [x] New feature (non-breaking change which adds functionality)

## How has this been tested?

It has not, will will need to do a release for it to run.

## Checklist:

- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have performed a self-review of my own code
- [x] I have requested review from the maintainers
- [x] My code follows the [style guidelines](https://github.com/Practically/conventional-tools/blob/1.x/CONTRIBUTING.md#coding-style) of this project
- [x] My commits are [formatted correctly](https://github.com/Practically/conventional-tools/blob/1.x/CONTRIBUTING.md#committing-convention)