### PR TITLE
docs(core): update reference to conventional tools image namespace

### DIFF
--- a/.github/workflows/ct-release.yml
+++ b/.github/workflows/ct-release.yml
@@ -13,7 +13,7 @@ jobs:
   release:
     name: Release
     runs-on: ubuntu-latest
-    container: registry.k1.zportal.co.uk/practically-oss/conventional-tools:1.x
+    container: practically/conventional-tools:1.x@sha256:e0603c12e8b4b835c9fcceaa4ddad4077ccf223665c0180db91511e2ce168670
     env:
       CT_TOKEN: ${{ secrets.GITHUB_TOKEN }}
     steps:

--- a/docs/commitlint.md
+++ b/docs/commitlint.md
@@ -93,7 +93,7 @@ You can run commitlint in your CI pipelines with the bellow example config.
 ```yaml
 lint:commits:
   stage: lint
-  image: registry.k1.zportal.co.uk/practically-oss/conventional-tools:0.x
+  image: practically/conventional-tools:1.x
   script:
     - conventional-tools commitlint -l1
 ```
@@ -111,7 +111,7 @@ commits:
         fetch-depth: 1000
 
     - name: Lint commits
-      uses: docker://registry.k1.zportal.co.uk/practically-oss/conventional-tools:0.x
+      uses: docker://practically/conventional-tools:1.x
       with:
         args: conventional-tools commitlint -l1
 ```

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -14,13 +14,12 @@ npm i -g @practically/conventional-tools
 
 ### Docker
 
-There is a docker build of both the latest stable and the next branch. This is
-meant to be used in CI however there is no reason you cant use it locally if you
-want to run it in a confined environment
+There is a docker build of the `1.x` branch. This is meant to be used in CI
+however there is no reason you can't use it locally if you want to run it in a
+confined environment
 
 ```sh
-docker run --rm -it registry.k1.zportal.co.uk/practically-oss/conventional-tools:latest conventional-tools --help
-docker run --rm -it registry.k1.zportal.co.uk/practically-oss/conventional-tools:next conventional-tools --help
+docker run --rm -it practically/conventional-tools:1.x:latest conventional-tools --help
 ```
 
 ### Source

--- a/docs/release-calver.md
+++ b/docs/release-calver.md
@@ -26,7 +26,7 @@ new release with every push to the master branch
 ```yaml
 release:
   stage: release
-  image: registry.k1.zportal.co.uk/practically-oss/conventional-tools:0.x
+  image: practically/conventional-tools:1.x
   variables:
     GIT_EMAIL: gitbot@practically.co.uk
     GIT_USER: Gitbot

--- a/docs/release-semver.md
+++ b/docs/release-semver.md
@@ -26,7 +26,7 @@ new release with every push to the master branch
 ```yaml
 release:
   stage: release
-  image: registry.k1.zportal.co.uk/practically-oss/conventional-tools:0.x
+  image: practically/conventional-tools:1.x
   variables:
     GIT_EMAIL: gitbot@practically.co.uk
     GIT_USER: Gitbot


### PR DESCRIPTION
@AdeAttwood I've noticed that on the [getting started section](https://github.com/Practically/conventional-tools/blob/1aa4c87eba181271e2db14ec726d35019896e870/docs/getting-started.md?plain=1#L22-L23) we're linking to `latest` and `next` tags for the image.

Do we want to carry on doing this? As these obviously don't exist yet in the registry.