### PR TITLE
ci: setup CI for the 2.x branch

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,41 +3,23 @@
 name: CI
 
 on:
-  push: { branches: ["1.x"] }
-  pull_request: { branches: ["1.x"] }
+  push: { branches: ["2.x"] }
+  pull_request: { branches: ["2.x"] }
 
 jobs:
-  # commits:
-  #   name: Lint commits
-  #   runs-on: ubuntu-latest
-  #   steps:
-  #     - name: Checkout
-  #       uses: actions/checkout@v2
-
-  #     - name: Set up Node
-  #       uses: actions/setup-node@v3
-  #       with:
-  #         node-version: 16
-
-  #     - name: Install dependencies and Prepack
-  #       run: yarn install && yarn prepack && rm -rf node_modules && NODE_ENV=production yarn install
-
-  #     - name: Lint
-  #       run: ./bin/run commitlint
-
   test:
     runs-on: ubuntu-latest
-    name: Test Node ${{ matrix.node-versions }}
+    name: Test Node ${{ matrix.node-version }}
     strategy:
       fail-fast: false
       matrix:
-        node-version: [14, 16, 18]
+        node-version: [18, 20]
     steps:
       - name: Checkout
         uses: actions/checkout@v2
 
       - name: Set up Node
-        uses: actions/setup-node@v2
+        uses: actions/setup-node@v4
         with:
           node-version: ${{ matrix.node-version }}
 

--- a/.github/workflows/ct-commitlint.yml
+++ b/.github/workflows/ct-commitlint.yml
@@ -1,0 +1,21 @@
+name: Conventional Tools Commitlint
+
+on:
+  push: { branches: ["2.x"] }
+  pull_request: { branches: ["2.x"] }
+
+jobs:
+  commits:
+    name: Commitlint
+    runs-on: ubuntu-latest
+    container: practically/conventional-tools:1.x@sha256:647d6e4b3edfcbac6054b90f74d2c61a022152751b94484d54e13695a9e27377
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+        with: {fetch-depth: 1000}
+
+      - name: Git safe.directory
+        run: git config --global --add safe.directory $PWD
+
+      - name: Lint commits
+        run: conventional-tools commitlint -l1


### PR DESCRIPTION
Summary:

This now sets up CI for the 2.x branch, as we are now working on that branch. We will still be maintaining the 1.x branch, but we will not be adding new features to it.

This also adds node 20 to the matrix of node versions to test against. Right now we are still running on node 14, but that can be up for discussion.

Test Plan:

This is only CI changes, so there are no changes to the codebase.