### PR TITLE
chore: fix the types in the tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,41 +3,23 @@
 name: CI
 
 on:
-  push: { branches: ["1.x"] }
-  pull_request: { branches: ["1.x"] }
+  push: { branches: ["2.x"] }
+  pull_request: { branches: ["2.x"] }
 
 jobs:
-  # commits:
-  #   name: Lint commits
-  #   runs-on: ubuntu-latest
-  #   steps:
-  #     - name: Checkout
-  #       uses: actions/checkout@v2
-
-  #     - name: Set up Node
-  #       uses: actions/setup-node@v3
-  #       with:
-  #         node-version: 16
-
-  #     - name: Install dependencies and Prepack
-  #       run: yarn install && yarn prepack && rm -rf node_modules && NODE_ENV=production yarn install
-
-  #     - name: Lint
-  #       run: ./bin/run commitlint
-
   test:
     runs-on: ubuntu-latest
-    name: Test Node ${{ matrix.node-versions }}
+    name: Test Node ${{ matrix.node-version }}
     strategy:
       fail-fast: false
       matrix:
-        node-version: [14, 16, 18]
+        node-version: [18, 20]
     steps:
       - name: Checkout
         uses: actions/checkout@v2
 
       - name: Set up Node
-        uses: actions/setup-node@v2
+        uses: actions/setup-node@v4
         with:
           node-version: ${{ matrix.node-version }}
 

--- a/.github/workflows/ct-commitlint.yml
+++ b/.github/workflows/ct-commitlint.yml
@@ -1,0 +1,21 @@
+name: Conventional Tools Commitlint
+
+on:
+  push: { branches: ["2.x"] }
+  pull_request: { branches: ["2.x"] }
+
+jobs:
+  commits:
+    name: Commitlint
+    runs-on: ubuntu-latest
+    container: practically/conventional-tools:1.x@sha256:647d6e4b3edfcbac6054b90f74d2c61a022152751b94484d54e13695a9e27377
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+        with: {fetch-depth: 1000}
+
+      - name: Git safe.directory
+        run: git config --global --add safe.directory $PWD
+
+      - name: Lint commits
+        run: conventional-tools commitlint -l1

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
   ],
   "scripts": {
     "test": "vitest tests",
-    "lint": "eslint src tests",
+    "lint": "tsc --noEmit --project tsconfig.eslint.json && eslint src tests",
     "build": "tsc"
   },
   "dependencies": {

--- a/tests/commands/commitgen.spec.ts
+++ b/tests/commands/commitgen.spec.ts
@@ -6,7 +6,7 @@ import * as sourceControl from '../../src/lib/source-control';
 
 declare module 'vitest' {
   export interface TestContext {
-    commandResult?: string;
+    commandResult?: number;
   }
 }
 
@@ -30,7 +30,7 @@ describe('command/commitgen', () => {
         }),
       );
 
-      ctx.commandResult = await handler({});
+      ctx.commandResult = await handler();
     });
 
     it('exits with a success status code', ctx => {

--- a/tsconfig.eslint.json
+++ b/tsconfig.eslint.json
@@ -4,5 +4,5 @@
     "noEmit": true,
     "allowJs": true
   },
-  "include": ["./**/*.js", "tests"]
+  "include": ["./**/*.js", "src", "tests"]
 }


### PR DESCRIPTION
Summary:

So, it turns out that we don't actually test the types in our tests. We have are running `tsc` in the when we are building the app. This only checks the types in the src directory.

This is now running tsc in the lint script. This will check the types in the test directory by using the `tsconfig.eslint.json` file, which has been updated to include all of the files in the src and tests directories. We need the two different configs so when we are building the app we don't include the test files in the output build.

Test Plan:

This was noticed when in the editor. It has been tested locally in the editor asserting that no typescript errors are visible. I have also added the tsc command to the lint script that run in CI so this will be picked up in the future.