### PR TITLE
feat: implement scopes in the commit message for commitgen

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,41 +3,23 @@
 name: CI
 
 on:
-  push: { branches: ["1.x"] }
-  pull_request: { branches: ["1.x"] }
+  push: { branches: ["2.x"] }
+  pull_request: { branches: ["2.x"] }
 
 jobs:
-  # commits:
-  #   name: Lint commits
-  #   runs-on: ubuntu-latest
-  #   steps:
-  #     - name: Checkout
-  #       uses: actions/checkout@v2
-
-  #     - name: Set up Node
-  #       uses: actions/setup-node@v3
-  #       with:
-  #         node-version: 16
-
-  #     - name: Install dependencies and Prepack
-  #       run: yarn install && yarn prepack && rm -rf node_modules && NODE_ENV=production yarn install
-
-  #     - name: Lint
-  #       run: ./bin/run commitlint
-
   test:
     runs-on: ubuntu-latest
-    name: Test Node ${{ matrix.node-versions }}
+    name: Test Node ${{ matrix.node-version }}
     strategy:
       fail-fast: false
       matrix:
-        node-version: [14, 16, 18]
+        node-version: [18, 20]
     steps:
       - name: Checkout
         uses: actions/checkout@v2
 
       - name: Set up Node
-        uses: actions/setup-node@v2
+        uses: actions/setup-node@v4
         with:
           node-version: ${{ matrix.node-version }}
 

--- a/.github/workflows/ct-commitlint.yml
+++ b/.github/workflows/ct-commitlint.yml
@@ -1,0 +1,21 @@
+name: Conventional Tools Commitlint
+
+on:
+  push: { branches: ["2.x"] }
+  pull_request: { branches: ["2.x"] }
+
+jobs:
+  commits:
+    name: Commitlint
+    runs-on: ubuntu-latest
+    container: practically/conventional-tools:1.x@sha256:647d6e4b3edfcbac6054b90f74d2c61a022152751b94484d54e13695a9e27377
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+        with: {fetch-depth: 1000}
+
+      - name: Git safe.directory
+        run: git config --global --add safe.directory $PWD
+
+      - name: Lint commits
+        run: conventional-tools commitlint -l1

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
   ],
   "scripts": {
     "test": "vitest tests",
-    "lint": "eslint src tests",
+    "lint": "tsc --noEmit --project tsconfig.eslint.json && eslint src tests",
     "build": "tsc"
   },
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
     "build": "tsc"
   },
   "dependencies": {
+    "yaml": "^2.4.1",
     "yargs": "^17.7.2"
   },
   "devDependencies": {

--- a/src/commands/commitgen.ts
+++ b/src/commands/commitgen.ts
@@ -1,3 +1,4 @@
+import {configGet} from '../lib/config';
 import {log} from '../lib/logger';
 import {getSourceControlProvider} from '../lib/source-control';
 
@@ -38,8 +39,7 @@ export async function handler(): Promise<number> {
   }
 
   const m = branch.match(/(\w+)\/([a-z0-9]+)-?/);
-  // TODO(AdeAttwood): Sort out getting stuff from the config `.ctrc.yml`
-  const scopes: string[] = [];
+  const scopes = configGet('commit.scopes', [] as string[]);
 
   const message = `# Generated commit message by conventional tools. If you do not want this
 # message please delete above the comments and save the file. This will then

--- a/src/lib/config.ts
+++ b/src/lib/config.ts
@@ -1,0 +1,50 @@
+import {existsSync, readFileSync} from 'fs';
+import {dirname, join} from 'path';
+import {parse} from 'yaml';
+
+/**
+ * Get a value from an object using a path. The path is a dot-separated string.
+ */
+function getObjectItem<T>(obj: any, path: string, value: T): T {
+  const arr = path.split('.');
+  while (arr.length && obj) {
+    const current = arr.shift();
+    if (current === undefined) {
+      break;
+    }
+
+    obj = obj[current];
+  }
+
+  return obj || value;
+}
+
+/**
+ * Finds the closest config file in the directory tree. If no file is found then
+ * it returns undefined.
+ */
+function getConfigFile(filePath: string) {
+  if (existsSync(join(filePath, '.ctrc.yml'))) {
+    return join(filePath, '.ctrc.yml');
+  }
+
+  if (filePath === '/') {
+    return undefined;
+  }
+
+  return getConfigFile(dirname(filePath));
+}
+
+/**
+ * Get a value from the config file. If the config file does not exist or the
+ * value is not found then it returns the default value.
+ */
+export function configGet<T>(path: string, defaultValue: T): T {
+  const configFilePath = getConfigFile(process.cwd());
+  if (!configFilePath) {
+    return defaultValue;
+  }
+
+  const parsed = parse(readFileSync(configFilePath, 'utf8'));
+  return getObjectItem(parsed, path, defaultValue);
+}

--- a/tests/commands/commitgen.spec.ts
+++ b/tests/commands/commitgen.spec.ts
@@ -6,7 +6,7 @@ import * as sourceControl from '../../src/lib/source-control';
 
 declare module 'vitest' {
   export interface TestContext {
-    commandResult?: string;
+    commandResult?: number;
   }
 }
 
@@ -30,7 +30,7 @@ describe('command/commitgen', () => {
         }),
       );
 
-      ctx.commandResult = await handler({});
+      ctx.commandResult = await handler();
     });
 
     it('exits with a success status code', ctx => {

--- a/tests/commands/commitgen.spec.ts
+++ b/tests/commands/commitgen.spec.ts
@@ -1,6 +1,7 @@
 import {beforeEach, describe, expect, it, vi} from 'vitest';
 
 import {handler} from '../../src/commands/commitgen';
+import * as config from '../../src/lib/config';
 import * as logger from '../../src/lib/logger';
 import * as sourceControl from '../../src/lib/source-control';
 
@@ -68,5 +69,26 @@ describe('command/commitgen', () => {
         );
       });
     }
+  });
+
+  describe('with a scopes in the config file', () => {
+    beforeEach(async ctx => {
+      vi.spyOn(config, 'configGet').mockReturnValue(['scope1', 'scope2']);
+
+      vi.spyOn(sourceControl, 'getSourceControlProvider').mockImplementation(
+        async () => ({
+          isEnabled: async () => true,
+          getBranchName: async () => `feat/123`,
+        }),
+      );
+
+      ctx.commandResult = await handler();
+    });
+
+    it('has the scopes in the commit message', () => {
+      expect(logger.log).toHaveBeenCalledWith(
+        expect.stringContaining('#   scope1, scope2'),
+      );
+    });
   });
 });

--- a/tests/lib/config.spec.ts
+++ b/tests/lib/config.spec.ts
@@ -1,0 +1,92 @@
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+
+import {beforeEach, describe, expect, it, vi} from 'vitest';
+
+import {configGet} from '../../src/lib/config';
+
+function setupConfigFile(workingDir: string, content: string) {
+  const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'ct-test-'));
+  fs.writeFileSync(`${tmpDir}/.ctrc.yml`, content);
+  fs.mkdirSync(path.join(tmpDir, workingDir), {recursive: true});
+
+  vi.spyOn(process, 'cwd').mockReturnValue(path.join(tmpDir, workingDir));
+}
+
+describe('lib/logger', () => {
+  describe('with a config file in the current working directory', () => {
+    beforeEach(() => {
+      setupConfigFile('.', 'testing: my value');
+    });
+
+    it('gets an item out of the config', () => {
+      expect(configGet('testing', 'default')).toBe('my value');
+    });
+
+    it('gets a default value out of the config', () => {
+      expect(configGet('missing', 'default')).toBe('default');
+    });
+  });
+
+  describe('with a config file in the parent directory', () => {
+    beforeEach(() => {
+      setupConfigFile('some/dir', 'testing: my value');
+    });
+
+    it('gets an item out of the config', () => {
+      expect(configGet('testing', 'default')).toBe('my value');
+    });
+
+    it('gets a default value out of the config', () => {
+      expect(configGet('missing', 'default')).toBe('default');
+    });
+  });
+
+  describe('with no config file in the root', () => {
+    beforeEach(() => {
+      const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'ct-test-'));
+      vi.spyOn(process, 'cwd').mockReturnValue(tmpDir);
+    });
+
+    it('returns the default value because no config file was found', () => {
+      expect(configGet('testing', 'default')).toBe('default');
+    });
+  });
+
+  describe('with a nested object in the config file', () => {
+    beforeEach(() => {
+      setupConfigFile('', 'testing:\n one: my value');
+    });
+
+    it('gets an item out of the config', () => {
+      expect(configGet('testing.one', 'default')).toBe('my value');
+    });
+
+    it('returns the default value if we access a key that dose not exist', () => {
+      expect(configGet('testing.two', 'default')).toBe('default');
+    });
+
+    it('returns the hole object if we access the parent key', () => {
+      expect(configGet('testing', 'default')).toStrictEqual({one: 'my value'});
+    });
+  });
+
+  describe('with a nested array in the config file', () => {
+    beforeEach(() => {
+      setupConfigFile('', 'testing:\n - my value');
+    });
+
+    it('gets the first array item out of the config', () => {
+      expect(configGet('testing.0', 'default')).toBe('my value');
+    });
+
+    it('returns the default value for a index that dose not exist', () => {
+      expect(configGet('testing.1', 'default')).toBe('default');
+    });
+
+    it('returns the whole array if we access the top level ket', () => {
+      expect(configGet('testing', 'default')).toStrictEqual(['my value']);
+    });
+  });
+});

--- a/tsconfig.eslint.json
+++ b/tsconfig.eslint.json
@@ -4,5 +4,5 @@
     "noEmit": true,
     "allowJs": true
   },
-  "include": ["./**/*.js", "tests"]
+  "include": ["./**/*.js", "src", "tests"]
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -1965,6 +1965,11 @@ yallist@^4.0.0:
   resolved "https://registry.yarnpkg.com/yallist/-/yallist-4.0.0.tgz#9bb92790d9c0effec63be73519e11a35019a3a72"
   integrity sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==
 
+yaml@^2.4.1:
+  version "2.4.1"
+  resolved "https://registry.yarnpkg.com/yaml/-/yaml-2.4.1.tgz#2e57e0b5e995292c25c75d2658f0664765210eed"
+  integrity sha512-pIXzoImaqmfOrL7teGUBt/T7ZDnyeGBWyXQBvOVhLkWLN37GXv8NMLK406UY6dS51JfcQHsmcW5cJ441bHg6Lg==
+
 yargs-parser@^21.1.1:
   version "21.1.1"
   resolved "https://registry.yarnpkg.com/yargs-parser/-/yargs-parser-21.1.1.tgz#9096bceebf990d21bb31fa9516e0ede294a77d35"


### PR DESCRIPTION
Summary:

We are now adding the scopes to the commit message when running `commitgen`. This is implements the same functionality as in V1.

Test Plan:

This has been tested with unit tests only