### PR TITLE
refactor: create handler wrapper to abstract the process access

### DIFF
--- a/src/commands/commitgen.ts
+++ b/src/commands/commitgen.ts
@@ -1,4 +1,5 @@
 import {configGet} from '../lib/config';
+import {handlerWrapper} from '../lib/handler-wrapper';
 import {log} from '../lib/logger';
 import {getSourceControlProvider} from '../lib/source-control';
 
@@ -72,9 +73,4 @@ ${message}
   return 0;
 }
 
-export default {
-  builder,
-  handler: async () => {
-    await handler();
-  },
-};
+export default {builder, handler: handlerWrapper(handler)};

--- a/src/lib/handler-wrapper.ts
+++ b/src/lib/handler-wrapper.ts
@@ -1,0 +1,13 @@
+import {error} from './logger';
+
+type Callback<T> = (args: T) => Promise<number>;
+
+// prettier-ignore
+export const handlerWrapper = <T>(cb: Callback<T>) => async (args: T) => {
+    try {
+      process.exit(await cb(args));
+    } catch (e) {
+      error((e as any).message)
+      process.exit(1);
+    }
+  };


### PR DESCRIPTION
refactor: create handler wrapper to abstract the process access

Summary:

Create a handler wrapper that will abstract the process and output handling
from the commands. Right now this just makes sure we are exiting with the
correct code. We can expand this to format the exception errors that get thrown
in the commands.

Test Plan:

Not tested yet, this will need to be done in integration tests

---
[//]: # (BEGIN SAPLING FOOTER)
Stack created with [Sapling](https://sapling-scm.com). Best reviewed with [ReviewStack](https://reviewstack.dev/Practically/Conventional-Tools/pull/88).
* #90
* #89
* #86
* #85
* __->__ #88