### PR TITLE
feat: implement sapling source control provider

### DIFF
--- a/.ctrc.yml
+++ b/.ctrc.yml
@@ -14,9 +14,9 @@ hooks:
         echo "$(conventional-tools commitgen)$(cat ${1})" > ${1};
       fi
   pre-commit:
-    - $(git rev-parse --show-toplevel)/.github/hooks/check-copyright.sh
-    - $(git rev-parse --show-toplevel)/.github/hooks/no-yaml-files.sh
-    - $(git rev-parse --show-toplevel)/.github/hooks/prettier.sh
+    - $(conventional-tools root)/.github/hooks/check-copyright.sh
+    - $(conventional-tools root)/.github/hooks/no-yaml-files.sh
+    - $(conventional-tools root)/.github/hooks/prettier.sh
 commit:
   scopes:
     - core

--- a/src/commands/root.ts
+++ b/src/commands/root.ts
@@ -1,0 +1,18 @@
+import {handlerWrapper} from '../lib/handler-wrapper';
+import {log} from '../lib/logger';
+import {getSourceControlProvider} from '../lib/source-control';
+
+export const builder = {} as const;
+
+export async function handler(): Promise<number> {
+  const sourceControl = await getSourceControlProvider();
+  if (!sourceControl) {
+    throw new Error('No source control provider found');
+  }
+
+  log(await sourceControl.root());
+
+  return 0;
+}
+
+export default {builder, handler: handlerWrapper(handler)};

--- a/src/index.ts
+++ b/src/index.ts
@@ -4,6 +4,7 @@ import {hideBin} from 'yargs/helpers';
 import commitgen from './commands/commitgen';
 import gitHook from './commands/git-hook';
 import gitHookInstall from './commands/git-hook:install';
+import root from './commands/root';
 
 export async function run(args: string[]) {
   await yargs(hideBin(args))
@@ -12,6 +13,12 @@ export async function run(args: string[]) {
       'Commit message generator',
       commitgen.builder,
       commitgen.handler,
+    )
+    .command(
+      'root',
+      'Gets the root directory of the current repository',
+      root.builder,
+      root.handler,
     )
     .command(
       'git-hook',

--- a/src/lib/source-control/git.ts
+++ b/src/lib/source-control/git.ts
@@ -12,6 +12,11 @@ const git: SourceControlProvider = {
 
     return stdout.trim();
   },
+
+  root: async () => {
+    const {stdout} = await run(`git rev-parse --show-toplevel`);
+    return stdout.trim();
+  },
 };
 
 export default git;

--- a/src/lib/source-control/index.ts
+++ b/src/lib/source-control/index.ts
@@ -1,4 +1,5 @@
 import git from './git';
+import sapling from './sapling';
 
 export interface SourceControlProvider {
   /**
@@ -11,9 +12,13 @@ export interface SourceControlProvider {
    * are not currently on one.
    */
   getBranchName(): Promise<string | null>;
+  /**
+   * Get the current root directory of for the repository.
+   */
+  root(): Promise<string>;
 }
 
-const PROVIDERS = [git];
+const PROVIDERS = [git, sapling];
 
 export async function getSourceControlProvider(): Promise<
   SourceControlProvider | undefined

--- a/src/lib/source-control/sapling.ts
+++ b/src/lib/source-control/sapling.ts
@@ -1,0 +1,25 @@
+import {run} from '../exec';
+import type {SourceControlProvider} from '.';
+
+const sapling: SourceControlProvider = {
+  isEnabled: async () => {
+    const isSapling = await run(`sl root`);
+    return isSapling.code === 0;
+  },
+
+  getBranchName: async () => {
+    const {stdout} = await run(`sl log -r '.' -T"{bookmarks}"`);
+    if (!stdout.trim()) {
+      return null;
+    }
+
+    return stdout.trim();
+  },
+
+  root: async () => {
+    const {stdout} = await run(`sl root`);
+    return stdout.trim();
+  },
+};
+
+export default sapling;


### PR DESCRIPTION
feat: implement sapling source control provider

Summary:

You can now use conventional tools in a sapling repo (maybe).

Test Plan:

This has not really been tested yet, but the code is there. This is very much a
WIP, the users will be using this at their own risk.

---
[//]: # (BEGIN SAPLING FOOTER)
Stack created with [Sapling](https://sapling-scm.com). Best reviewed with [ReviewStack](https://reviewstack.dev/Practically/Conventional-Tools/pull/89).
* #90
* __->__ #89
* #86
* #85