### PR TITLE
refactor: add root command to get the root of the current repository

### DIFF
--- a/.ctrc.yml
+++ b/.ctrc.yml
@@ -14,9 +14,9 @@ hooks:
         echo "$(conventional-tools commitgen)$(cat ${1})" > ${1};
       fi
   pre-commit:
-    - $(git rev-parse --show-toplevel)/.github/hooks/check-copyright.sh
-    - $(git rev-parse --show-toplevel)/.github/hooks/no-yaml-files.sh
-    - $(git rev-parse --show-toplevel)/.github/hooks/prettier.sh
+    - $(conventional-tools root)/.github/hooks/check-copyright.sh
+    - $(conventional-tools root)/.github/hooks/no-yaml-files.sh
+    - $(conventional-tools root)/.github/hooks/prettier.sh
 commit:
   scopes:
     - core

--- a/src/commands/root.ts
+++ b/src/commands/root.ts
@@ -1,0 +1,18 @@
+import {handlerWrapper} from '../lib/handler-wrapper';
+import {log} from '../lib/logger';
+import {getSourceControlProvider} from '../lib/source-control';
+
+export const builder = {} as const;
+
+export async function handler(): Promise<number> {
+  const sourceControl = await getSourceControlProvider();
+  if (!sourceControl) {
+    throw new Error('No source control provider found');
+  }
+
+  log(await sourceControl.root());
+
+  return 0;
+}
+
+export default {builder, handler: handlerWrapper(handler)};

--- a/src/index.ts
+++ b/src/index.ts
@@ -4,6 +4,7 @@ import {hideBin} from 'yargs/helpers';
 import commitgen from './commands/commitgen';
 import gitHook from './commands/git-hook';
 import gitHookInstall from './commands/git-hook:install';
+import root from './commands/root';
 
 export async function run(args: string[]) {
   await yargs(hideBin(args))
@@ -12,6 +13,12 @@ export async function run(args: string[]) {
       'Commit message generator',
       commitgen.builder,
       commitgen.handler,
+    )
+    .command(
+      'root',
+      'Gets the root directory of the current repository',
+      root.builder,
+      root.handler,
     )
     .command(
       'git-hook',

--- a/src/lib/source-control/git.ts
+++ b/src/lib/source-control/git.ts
@@ -12,6 +12,11 @@ const git: SourceControlProvider = {
 
     return stdout.trim();
   },
+
+  root: async () => {
+    const {stdout} = await run(`git rev-parse --show-toplevel`);
+    return stdout.trim();
+  },
 };
 
 export default git;


### PR DESCRIPTION
refactor: add root command to get the root of the current repository

Summary:

Right now in our git hooks we are using `git rev-parse --show-toplevel` to get
the root of the repository. This is not working within a sapling repo.

This implements the root command so we can use that instead. It as a new `root`
method to the `SourceControlProvider` interface. This will then be implemented
by any provider we want to.

Test Plan:

No real way to test this other than running the command and checking the
output. As long as the hooks commands will be working for us this will be fine
for now.

---
[//]: # (BEGIN SAPLING FOOTER)
Stack created with [Sapling](https://sapling-scm.com). Best reviewed with [ReviewStack](https://reviewstack.dev/Practically/Conventional-Tools/pull/90).
* __->__ #90
* #89
* #86
* #85