### PR TITLE
fix(git-hooks): non interactive hooks

### DIFF
--- a/.ctrc.yml
+++ b/.ctrc.yml
@@ -14,9 +14,9 @@ hooks:
         echo "$(conventional-tools commitgen)$(cat ${1})" > ${1};
       fi
   pre-commit:
-    - $(git rev-parse --show-toplevel)/.github/hooks/check-copyright.sh
-    - $(git rev-parse --show-toplevel)/.github/hooks/no-yaml-files.sh
-    - $(git rev-parse --show-toplevel)/.github/hooks/prettier.sh
+    - $(conventional-tools root)/.github/hooks/check-copyright.sh
+    - $(conventional-tools root)/.github/hooks/no-yaml-files.sh
+    - $(conventional-tools root)/.github/hooks/prettier.sh
 commit:
   scopes:
     - core

--- a/src/commands/git-hook.ts
+++ b/src/commands/git-hook.ts
@@ -24,12 +24,9 @@ export async function handler(args: Arguments<Options>): Promise<number> {
 
   runner.start();
 
-  writer.print(runner);
-  const ticker = setInterval(() => writer.update(runner), 80);
-  await runner.wait();
-
-  clearInterval(ticker);
-  writer.update(runner);
+  process.stdout.isTTY
+    ? await interactive(runner, writer)
+    : await nonInteractive(runner, writer);
 
   let exitCode = 0;
   for (const command of runner) {
@@ -47,6 +44,21 @@ export async function handler(args: Arguments<Options>): Promise<number> {
   }
 
   return exitCode;
+}
+
+async function interactive(runner: Runner, writer: Writer) {
+  writer.print(runner);
+  const ticker = setInterval(() => writer.update(runner), 80);
+
+  await runner.wait();
+
+  clearInterval(ticker);
+  writer.update(runner);
+}
+
+async function nonInteractive(runner: Runner, writer: Writer) {
+  writer.print(runner);
+  await runner.wait();
 }
 
 export default {builder, handler: handlerWrapper(handler)};

--- a/src/commands/root.ts
+++ b/src/commands/root.ts
@@ -1,0 +1,18 @@
+import {handlerWrapper} from '../lib/handler-wrapper';
+import {log} from '../lib/logger';
+import {getSourceControlProvider} from '../lib/source-control';
+
+export const builder = {} as const;
+
+export async function handler(): Promise<number> {
+  const sourceControl = await getSourceControlProvider();
+  if (!sourceControl) {
+    throw new Error('No source control provider found');
+  }
+
+  log(await sourceControl.root());
+
+  return 0;
+}
+
+export default {builder, handler: handlerWrapper(handler)};

--- a/src/index.ts
+++ b/src/index.ts
@@ -4,6 +4,7 @@ import {hideBin} from 'yargs/helpers';
 import commitgen from './commands/commitgen';
 import gitHook from './commands/git-hook';
 import gitHookInstall from './commands/git-hook:install';
+import root from './commands/root';
 
 export async function run(args: string[]) {
   await yargs(hideBin(args))
@@ -12,6 +13,12 @@ export async function run(args: string[]) {
       'Commit message generator',
       commitgen.builder,
       commitgen.handler,
+    )
+    .command(
+      'root',
+      'Gets the root directory of the current repository',
+      root.builder,
+      root.handler,
     )
     .command(
       'git-hook',

--- a/src/lib/source-control/git.ts
+++ b/src/lib/source-control/git.ts
@@ -12,6 +12,11 @@ const git: SourceControlProvider = {
 
     return stdout.trim();
   },
+
+  root: async () => {
+    const {stdout} = await run(`git rev-parse --show-toplevel`);
+    return stdout.trim();
+  },
 };
 
 export default git;


### PR DESCRIPTION
fix(git-hooks): non interactive hooks

Summary:

When you are running hooks in a non interactive terminal, the hooks will fail
as they are expecting user input. This change will allow the hooks to run in a
non interactive terminal.

It splits out the writer to not show progress when when running in a non
interactive. You will now only get the output at the end of the process to see
what has passed and filed.

Test Plan:

No tests for now, this is quite hard to test because we are not actually
testing in a live terminal, everything is mocked.

---
[//]: # (BEGIN SAPLING FOOTER)
Stack created with [Sapling](https://sapling-scm.com). Best reviewed with [ReviewStack](https://reviewstack.dev/Practically/Conventional-Tools/pull/91).
* __->__ #91
* #94