### PR TITLE
ci: allow the `deps` scope for commits

### DIFF
--- a/.ctrc.yml
+++ b/.ctrc.yml
@@ -27,5 +27,6 @@ commit:
     - release-semver
     - release-calver
     - git-hooks
+    - deps
 assets:
   - dist/*


### PR DESCRIPTION
ci: allow the `deps` scope for commits

Summary:

All the renovate PRs are failing because of the commit message scope. In our
commit lint config we don't allow the deps scope so, all the commit messages
are failing.

Test Plan:

This is quite hard to test ATM. I think the easiest way todo it is to merge and
see if renovate is happy

Ref: #95
